### PR TITLE
Add options to control the order of profile output.

### DIFF
--- a/profile-doc/profile/scribblings/renderers.scrbl
+++ b/profile-doc/profile/scribblings/renderers.scrbl
@@ -23,6 +23,7 @@ function that consumes a @racket[profile] instance.  See the
 
 @defproc[(render
           [profile-data profile?]
+          [order (or/c 'topological 'self 'total) 'topological]
           [#:truncate-source truncate-source exact-nonnegative-integer? 50]
           [#:hide-self hide-self% (between/c 0 1) 1/100]
           [#:hide-subs hide-subs% (between/c 0 1) 2/100])
@@ -32,7 +33,7 @@ Prints the given @racket[profile] results as a textual table.
 
 The printout begins with general information about the profile,
 followed by a table with an entry for each node in the call graph.
-The entries are displayed in a topological order (roughly, since the
+The entries are displayed in a topological order by default (roughly, since the
 graph can have cycles).  This means that it is usually easy to find
 the callers and callees of a function in its close environment.
 
@@ -105,6 +106,13 @@ The function has a few keyword arguments to customize its output:
   conditions is to avoid having ``dangling references'' to hidden
   nodes.}
 
+@item{The @racket[order] argument determines the order in which entries
+  appear in the output. If @racket[order] is @racket['topological] (the default),
+  entries are sorted topologically, grouping callers and callees close together.
+  If @racket[order] is @racket['self], entries are sorted by how often
+  they appear at the top of a stack snapshot. If @racket[order] is @racket['total],
+  entries are sorted by how often they appear anywhere in a stack snapshot.}
+
 ]}
 
 
@@ -115,6 +123,7 @@ The function has a few keyword arguments to customize its output:
 
 @defproc[(render
           [profile-data profile?]
+          [order (or/c 'topological 'self 'total) 'topological]
           [#:hide-self hide-self% (between/c 0 1) 1/100]
           [#:hide-subs hide-subs% (between/c 0 1) 2/100])
          void?]{
@@ -128,4 +137,4 @@ of the Graphviz tools to render.  Nodes are colored according to their
 `self' percentages, and edges.
 
 The keyword arguments control hiding nodes in the same way as with the
-textual renderer.}
+textual renderer. The @racket[order] argument is ignored.}

--- a/profile-doc/profile/scribblings/toplevel.scrbl
+++ b/profile-doc/profile/scribblings/toplevel.scrbl
@@ -30,12 +30,15 @@ intended as a convenient tool for profiling code.
           [#:delay   delay      (>=/c 0.0)        0.05]
           [#:repeat  iterations exact-nonnegative-integer? 1]
           [#:threads threads?   any/c                      #f]
-          [#:render  renderer   (profile? . -> . any/c)    text:render]
+          [#:render  renderer   (-> profile? (or/c 'topological 'self 'total) any/c)    text:render]
           [#:periodic-renderer periodic-renderer
            (or/c #f (list/c (>=/c 0.0)
-                            (profile? . -> . any/c)))
+                            (-> profile?
+                                (or/c 'topological 'self 'total)
+                                any/c)))
            #f]
-          [#:use-errortrace? use-errortrace? any/c #f])
+          [#:use-errortrace? use-errortrace? any/c #f]
+          [#:order order (or/c 'topological 'self 'total) 'topological])
          any/c]{
 
 Executes the given @racket[thunk] and collect profiling data during
@@ -88,6 +91,12 @@ Keyword arguments can customize the profiling:
   using @racket[errortrace-compile-handler], and the profiled program must be
   run using @commandline{racket -l errortrace -t program.rkt} Removing compiled
   files (with extension @tt{.zo}) is sufficient to enable this.}
+
+@item{The @racket[order] value is passed to the @racket[renderer] to control the
+  order of its output. By default, entries in the profile are sorted
+  topologically, but they can also be sorted by the time an entry is on top of
+  the stack (@racket['self]) or appears anywhere on the stack (@racket['total]).
+  Some renderers may ignore this option.}
 ]}
 
 @defform[(profile expr keyword-arguments ...)]{

--- a/profile-lib/raco.rkt
+++ b/profile-lib/raco.rkt
@@ -3,7 +3,8 @@
 (require racket/cmdline
          raco/command-name
          errortrace/errortrace-lib
-         "main.rkt" "raco-utils.rkt")
+         "main.rkt" "raco-utils.rkt"
+         (prefix-in text: "render-text.rkt"))
 
 ;; raco profile
 ;; profile the main submodule (if there is one), or the top-level module
@@ -12,6 +13,7 @@
 (define iterations #f)
 (define threads? #f)
 (define use-errortrace? #f)
+(define order 'topological)
 (define file
   (command-line #:program (short-program+command-name)
                 #:once-each
@@ -33,6 +35,16 @@
                 [("--use-errortrace")
                  "Use errortrace mode"
                  (set! use-errortrace? #t)]
+                #:once-any
+                [("--topological")
+                 "Order functions topologically (the default)"
+                 (set! order 'topological)]
+                [("--self")
+                 "Order functions by self time"
+                 (set! order 'self)]
+                [("--total")
+                 "Order functions by total time"
+                 (set! order 'total)]
                 #:args (filename)
                 filename))
 
@@ -49,20 +61,24 @@
          (profile-thunk t
                         #:delay delay
                         #:repeat iterations
+                        #:order order
                         #:threads threads?
                         #:use-errortrace? use-errortrace?)]
         [delay
           (profile-thunk t
                          #:delay delay
+                         #:order order
                          #:threads threads?
                          #:use-errortrace? use-errortrace?)]
         [iterations
          (profile-thunk t
                         #:repeat iterations
+                        #:order order
                         #:threads threads?
                         #:use-errortrace? use-errortrace?)]
         [else
          (profile-thunk t
+                        #:order order
                         #:threads threads?
                         #:use-errortrace? use-errortrace?)]))
 

--- a/profile-lib/render-graphviz.rkt
+++ b/profile-lib/render-graphviz.rkt
@@ -5,6 +5,7 @@
 (require "analyzer.rkt" "utils.rkt")
 
 (define (render profile
+                [order 'topological]
                 #:hide-self [hide-self% 1/100]
                 #:hide-subs [hide-subs% 2/100])
   (define *-node (profile-*-node profile))


### PR DESCRIPTION
I often find myself wanting to sort profiler output differently. This PR adds flags to the text renderer and `raco profile` to sort profile output by self time or total time. The default (topological) order remains unchanged.