### PR TITLE
Supply arguments to the program being profiled

### DIFF
--- a/profile-lib/raco.rkt
+++ b/profile-lib/raco.rkt
@@ -45,8 +45,10 @@
                 [("--total")
                  "Order functions by total time"
                  (set! order 'total)]
-                #:args (filename)
-                filename))
+                #:args (file.rkt . arg-for-file.rkt)
+                (current-command-line-arguments
+                 (list->vector arg-for-file.rkt))
+                file.rkt))
 
 (define (t)
   ;; use a fresh namespace every time, to play nice with --repeat


### PR DESCRIPTION
Permit profiling programs that take command-line arguments.

For example

    racket foo.rkt --bar --baz whatever

can be profiled with

    raco profile --all-threads --use-errortrace foo.rkt --bar --baz whatever