### PR TITLE
Add utility function to merge two profiles

### DIFF
--- a/profile-doc/profile/scribblings/analyzer.scrbl
+++ b/profile-doc/profile/scribblings/analyzer.scrbl
@@ -75,6 +75,16 @@ Represents an analyzed profile result.
 
 ]}
 
+@defproc[(profile-merge [profile profile?] ...)
+         profile?]{
+
+This function combines multiple profiles into a single one. This is
+most useful when the multiple profiles are for multiple runs of the
+same code. The total time for the output profile is the sum of the
+total times of the input profiles, and the total and self times for
+each output profile node is the sum of its total and self times in
+each input profile.}
+
 
 @defstruct*[node ([id      (or/c #f symbol? any/c)]
                   [src     (or/c #f srcloc?)]

--- a/profile-test/tests/profile/analyze.rkt
+++ b/profile-test/tests/profile/analyze.rkt
@@ -107,3 +107,16 @@
      [bad (error 'test ">>> ~s" bad)])
 
    ))
+
+(provide merge-test)
+(module+ main (merge-tests))
+(define (merge-tests)
+  (define (workload n) (if (= n 0) '(0 1) (cartesian-product (workload (- n 1)) '(0 1))))
+  (test
+   (define p1 (let/ec ec (profile-thunk (lambda () (workload 20)) #:render (lambda (a b) (ec a)))))
+   (define p2 (let/ec ec (profile-thunk (lambda () (workload 20)) #:render (lambda (a b) (ec a)))))
+   (define pm (profile-merge p1 p2))
+   (unless (= (profile-total-time pm) (+ (profile-total-time p1) (profile-total-time p2)))
+     (error 'test "Total time does not match"))
+   (unless (= (profile-cpu-time pm) (+ (profile-cpu-time p1) (profile-cpu-time p2)))
+     (error 'test "Total time does not match"))))


### PR DESCRIPTION
This PR contains code extracted from Herbie to merge two profiles. Theoretically, a profile is a weighted directed graph; merging two profiles just overlays the graphs and sums the weights. Another perspective is that a profile is a markov chain model of the set of stacks sampled by the profiler; merging the profiles models the union of the stack sets modeled by each profile. To match functions between the two profiles, profile merging relies on srclocs.

Merging profiles is useful when you want to profile a subset of your program that runs many times; it can also be useful if the program runs on multiple machines and you want to get an overview. In that case it combines well with the recently merged `profile->json` converter.

This PR is a work in progress. It still needs:

- [x] Documentation
- [x] Tests