### PR TITLE
Use hash tables and a better algorithm for profile analysis

### DIFF
--- a/profile-lib/utils.rkt
+++ b/profile-lib/utils.rkt
@@ -102,9 +102,9 @@
   ;; list we scan is in reverse order.
   (define acyclic-order
     (let* ([todo (make-hasheq nodes+io-times)]
-           [sinks (for/list ([(k v) (in-hash todo)] #:when (zero? (mcdr v))) k)]
-           [sources (for/list ([(k v) (in-hash todo)] #:when (zero? (mcar v))) k)])
-      (let loop ([todo todo] [rev-left '()] [right '()] [sinks sinks] [sources sources])
+           [init-sinks (for/list ([(k v) (in-hash todo)] #:when (zero? (mcdr v))) k)]
+           [init-sources (for/list ([(k v) (in-hash todo)] #:when (zero? (mcar v))) k)])
+      (let loop ([todo todo] [rev-left '()] [right '()] [sinks init-sinks] [sources init-sources])
         ;; heuristic for best sources: the ones with the lowest intime/outtime
         (define (best-sources)
           (let loop ([todo (hash->list todo)] [r '()] [best #f])
@@ -124,10 +124,10 @@
 
           [else
            (for-each (lambda (sink) (hash-remove! todo sink)) sinks)
-           (define sources
+           (define actual-sources
              (if (and (null? sinks) (null? sources))
                  (best-sources) sources))
-           (for-each (lambda (source) (hash-remove! todo source)) sources)
+           (for-each (lambda (source) (hash-remove! todo source)) actual-sources)
            (define sinks* '())
            (define sources* '())
            ;; remove the source and sink times from the rest


### PR DESCRIPTION
Profile analysis can be extremely slow for large profiles (see #9). This PR fixes this, basically by using hash tables for sets and dictionaries instead of linked lists. This seems to improve performance asymptotically. Specifically:

- `get-counts` now uses an O(d) hash table instead of an O(d^2) repeated scan
- `stack+counts` now uses hash table lookup instead of possibly O(d^2) repeated scan
- `nodes+io-times` now uses two hash tables instead of repeated `assq` and `memq`
- `acyclic-order` now uses a hash table instead of repeated `assq`
- `acyclic-order` now also identifies sources and sinks when removing their last incoming/outgoing edge, not by repeatedly scanning the graph

I believe the results are the same, though don't merge this without testing it (I will test too and report results).