### PR TITLE
Use hash tables and triggers to do the topological sort much faster

### DIFF
--- a/profile-lib/analyzer.rkt
+++ b/profile-lib/analyzer.rkt
@@ -128,18 +128,12 @@
   h)
 
 (module+ test
-  (define (hash=? a b)
-    (and
-     (for/and ([(k v) (in-hash a)])
-       (= v (hash-ref b k)))
-     (for/and ([(k v) (in-hash b)])
-       (= v (hash-ref a k)))))
-  (check hash=? (get-counts '()) #hasheq())
-  (check hash=? (get-counts '(1)) #hasheq([1 . 1]))
-  (check hash=? (get-counts '(1 1 1)) #hasheq([1 . 3]))
-  (check hash=? (get-counts '(1 2 3)) #hasheq([1 . 1] [2 . 1] [3 . 1]))
-  (check hash=? (get-counts '(1 2 2 3 3 3)) #hasheq([1 . 1] [2 . 2] [3 . 3]))
-  (check hash=? (get-counts '(3 1 2 3 2 3)) #hasheq([1 . 1] [2 . 2] [3 . 3])))
+  (check equal? (get-counts '()) (make-hasheq))
+  (check equal? (get-counts '(1)) (make-hasheq '([1 . 1])))
+  (check equal? (get-counts '(1 1 1)) (make-hasheq '([1 . 3])))
+  (check equal? (get-counts '(1 2 3)) (make-hasheq '([1 . 1] [2 . 1] [3 . 1])))
+  (check equal? (get-counts '(1 2 2 3 3 3)) (make-hasheq '([1 . 1] [2 . 2] [3 . 3])))
+  (check equal? (get-counts '(3 1 2 3 2 3)) (make-hasheq '([1 . 1] [2 . 2] [3 . 3]))))
 
 (define (node-loc node)
   (cons (node-id node) (node-src node)))


### PR DESCRIPTION
A replacement for #10, fixing #9. Basically, I redid the optimizations while fixing bugs & cleaning up some of the code to look more like "modern Racket" at least as I understand it. This one is, I believe, ready to merge.

- `get-counts` now uses an O(d) hash table instead of an O(d^2) repeated scan
- `stack+counts` now uses hash table lookup instead of possibly O(d^2) repeated scan
- `nodes+io-times` now uses two hash tables instead of repeated `assq` and `memq`
- `acyclic-order` now uses a hash table instead of repeated `assq`
- `acyclic-order` now also identifies sources and sinks when removing their last incoming/outgoing edge, not by repeatedly scanning the graph

Along the way, I rewrite some `let loop` based loops into `for` loops to match more-modern Racket.