### PR TITLE
Hold target threads weakly so they can die

### DIFF
--- a/profile-lib/sampler.rkt
+++ b/profile-lib/sampler.rkt
@@ -132,10 +132,8 @@
     (sleep delay)
     (define run-again?
       (let loop ([t weak-to-track])
-        (cond [(paused . > . 0)
-               #t]
-              [(eq? t sampler-thread)
-               #f]
+        (cond [(paused . > . 0) #t]
+              [(eq? t sampler-thread) #f]
               [(thread? t)
                (when custom-keys
                  (set! custom-snapshots

--- a/profile-lib/sampler.rkt
+++ b/profile-lib/sampler.rkt
@@ -123,11 +123,10 @@
   (define weak-to-track
     (let loop ([t to-track])
       (cond [(thread? t) (make-weak-box t)]
-            [(custodian? t) (make-weak-box t)]
             [(list? t) (map loop t)]
             ;; cannot assume that it's a list: we might get other values from
             ;; a custodian managed list
-            [else (make-weak-box t)])))
+            [else t])))
 
   (define (sampler)
     (sleep delay)


### PR DESCRIPTION
**Background:** The profiler works by starting a sampler thread, which periodically wakes up and records the stack of the thread being profiled. Now, in Racket threads can be GC'd if they are guaranteed to never run again, for example if they are waiting on an event that got GC'd so can never fire, or maybe they were suspended and all references lost. GCing threads is important because threads can hold on to a lot of memory via their continuations.

**Problem:** The sampler thread of course needs to hold a reference to its target thread in order to be able to capture its stack. Currently the sampler thread holds that reference strongly. It'll thus keep alive its target thread, too. This can lead to bad behaviors, however. For example, imagine an `engine` starts a thread, which starts recording a profile but times out before finishing the profile. The timed-out thread is suspended by the engine, so it'll never stop the sampler thread, which will now run forever. But then the sampler thread will stay live and thus keep the suspended thread alive. This caused a bug in Herbie.

**Fix:** To fix this issue this PR makes two changes. First, the sampler thread holds all its target threads and custodians weakly. This allows the target thread to be GC'd. Also, if all the threads the sampler thread is watching are dead, the sampler itself will stop; this is a logical consequence of weakly holding target threads; once all the target threads are dead, there's literally nothing for the sampler thread to do.

**Correctness:** This *does* cause a behavior change in some unusual cases. For example, suppose thread A starts thread B and also a sampler thread C. It then suspends thread B and drops the reference to it, but keeps the reference to the sampler. Currently the sampler C would accumulate many copies of the same B stack frame forever, and thread A could read those because the profile library does expose the sampler interface. In the new code that's not possible; thread B will die, thread C will stop recording its stack frames, and then thread A will see fewer stack frames than before. I think the change in semantics is worth it because the alternative is a likely memory leak, and the cases that differ are precisely those where the sampler will run forever, recording the same stack frame forever and leaking memory.

**Design choices:** One bit of the code I couldn't quite figure out is what to do when the sampler targets a custodian. There are two options:
- If the sampler holds the custodian strongly, then the custodian can stay alive forever. But this might not be so bad, custodians are small and they hold their contents weakly
- If the sampler holds the custodian weakly, then the custodian can get GC'd, passing the threads it owns to its parent custodian. The sampler will then exit, since it'll have nothing to watch.
After some back and forth I decided that the first option was better. It *can* cause a memory leak, but it's basically guaranteed to be small. By contrast the second option can lead to weird semantics where threads continue running but the sampler stops watching them mysteriously. I'm willing to go the other way on custodians, though, if the memory leak is more of a concern than the exact semantics of thread watching when asked to watch a dead custodian.